### PR TITLE
Use wireplumber for Waybar volume

### DIFF
--- a/sway/config
+++ b/sway/config
@@ -85,7 +85,7 @@ bindsym $mod+Shift+7 move container to workspace number 7
 bindsym $mod+Shift+8 move container to workspace number 8
 bindsym $mod+Shift+9 move container to workspace number 9
 bindsym $mod+Shift+0 move container to workspace number 10
-
+# Volume keys using Pipewire
 bindsym XF86AudioRaiseVolume exec wpctl set-volume -l 1.0 @DEFAULT_AUDIO_SINK@ 5%+
 bindsym XF86AudioLowerVolume exec wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-
 bindsym XF86AudioMute exec wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle

--- a/sway/config
+++ b/sway/config
@@ -86,6 +86,10 @@ bindsym $mod+Shift+8 move container to workspace number 8
 bindsym $mod+Shift+9 move container to workspace number 9
 bindsym $mod+Shift+0 move container to workspace number 10
 
+bindsym XF86AudioRaiseVolume exec wpctl set-volume -l 1.0 @DEFAULT_AUDIO_SINK@ 5%+
+bindsym XF86AudioLowerVolume exec wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-
+bindsym XF86AudioMute exec wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle
+
 bar {
   swaybar_command waybar
 }

--- a/waybar/config
+++ b/waybar/config
@@ -2,7 +2,7 @@
   "layer": "top",
   "position": "top",
   "modules-left": ["sway/workspaces"],
-  "modules-right": ["clock","network", "battery", "custom/power"],
+  "modules-right": ["clock","network", "wireplumber", "battery", "custom/power"],
 
   "workspaces": {
     "all-outputs": true
@@ -28,6 +28,13 @@
     "format-disconnected": "⚠ Disconnected",
     "tooltip-format": "{ifname} • {ipaddr}/{cidr}",
     "interval": 5
+  },
+
+  "wireplumber": {
+    "format": "{volume}% {icon}",
+    "format-muted": "",
+    "format-icons": ["", ""],
+    "scroll-step": 5
   },
 
   "custom/power": {

--- a/waybar/config
+++ b/waybar/config
@@ -23,9 +23,9 @@
 
   "network": {
     "interface": "wlan0",
-    "format-wifi": " {signalStrength}%",
-    "format-ethernet": "",
-    "format-disconnected": "⚠",
+    "format-wifi": " {essid} ({signalStrength}%)",
+    "format-ethernet": " {ipaddr}",
+    "format-disconnected": "⚠ Disconnected",
     "tooltip-format": "{ifname} • {ipaddr}/{cidr}",
     "interval": 5
   },

--- a/waybar/config
+++ b/waybar/config
@@ -2,7 +2,7 @@
   "layer": "top",
   "position": "top",
   "modules-left": ["sway/workspaces"],
-  "modules-right": ["clock","network", "wireplumber", "battery", "custom/power"],
+  "modules-right": ["clock", "network", "wireplumber", "battery", "custom/power"],
 
   "workspaces": {
     "all-outputs": true
@@ -10,28 +10,28 @@
 
   "modules-center": ["sway/window"],
   "clock": {
-    "format": " {:%Y-%m-%d %H:%M}",
+    "format": " {:%H:%M}",
     "tooltip-format": "{:%A, %B %d %Y}",
     "interval": 60
   },
 
   "battery": {
-    "format": "{capacity}% {icon}",
+    "format": "{icon} {capacity}%",
     "format-icons": ["", "", "", "", ""],
     "tooltip": true
   },
 
   "network": {
     "interface": "wlan0",
-    "format-wifi": " {essid} ({signalStrength}%)",
-    "format-ethernet": " {ipaddr}",
-    "format-disconnected": "⚠ Disconnected",
+    "format-wifi": " {signalStrength}%",
+    "format-ethernet": "",
+    "format-disconnected": "⚠",
     "tooltip-format": "{ifname} • {ipaddr}/{cidr}",
     "interval": 5
   },
 
   "wireplumber": {
-    "format": "{volume}% {icon}",
+    "format": "{icon} {volume}%",
     "format-muted": "",
     "format-icons": ["", ""],
     "scroll-step": 5

--- a/waybar/style.css
+++ b/waybar/style.css
@@ -12,7 +12,7 @@
 
 * {
   font-family: JetBrainsMono Nerd Font, monospace;
-  font-size: 14px;
+  font-size: 12px;
 }
 
 window#waybar {
@@ -41,22 +41,22 @@ window#waybar {
 
 #clock {
   color: @cyan;
-  padding: 0 10px;
+  padding: 0 6px;
 }
 
 #battery {
   color: @green;
-  padding: 0 10px;
+  padding: 0 6px;
 }
 
 #wireplumber {
   color: @orange;
-  padding: 0 10px;
+  padding: 0 6px;
 }
 
 #custom-power {
   color: @red;
-  padding: 0 10px;
+  padding: 0 6px;
   font-weight: bold;
 }
 

--- a/waybar/style.css
+++ b/waybar/style.css
@@ -41,22 +41,22 @@ window#waybar {
 
 #clock {
   color: @cyan;
-  padding: 0 6px;
+  padding: 0 8px;
 }
 
 #battery {
   color: @green;
-  padding: 0 6px;
+  padding: 0 8px;
 }
 
 #wireplumber {
   color: @orange;
-  padding: 0 6px;
+  padding: 0 8px;
 }
 
 #custom-power {
   color: @red;
-  padding: 0 6px;
+  padding: 0 8px;
   font-weight: bold;
 }
 

--- a/waybar/style.css
+++ b/waybar/style.css
@@ -49,6 +49,11 @@ window#waybar {
   padding: 0 10px;
 }
 
+#wireplumber {
+  color: @orange;
+  padding: 0 10px;
+}
+
 #custom-power {
   color: @red;
   padding: 0 10px;


### PR DESCRIPTION
## Summary
- switch volume module to `wireplumber` to use Pipewire backend
- update styles for the new module

## Testing
- `nix flake check --impure` *(fails: `nix` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68638dbec1fc833383a41b08ef0c47da